### PR TITLE
[google] generate and store cluster name

### DIFF
--- a/bin/bootstrap-infrastructure-google
+++ b/bin/bootstrap-infrastructure-google
@@ -112,6 +112,7 @@ describe() {
 }
 
 down() {
+  [[ -f state/google/cluster-name ]] || { echo "No record of provisioned cluster."; exit 1; }
   _setup_env
   [[ "${CREDHUB_BASE_PATH:-X}" != "X" ]] && {
     echo "Deleting values from Credhub ${CREDHUB_BASE_PATH}..."

--- a/bin/bootstrap-infrastructure-google
+++ b/bin/bootstrap-infrastructure-google
@@ -7,7 +7,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 _cluster_name() {
   [[ -f state/google/cluster-name ]] || {
     mkdir -p state/google
-    ${CLUSTER_NAME:="$(whoami)-$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 6 ; echo)"}
+    ${CLUSTER_NAME:="$(whoami)-$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 6)"}
     echo "$CLUSTER_NAME" > state/google/cluster-name
   }
   cat state/google/cluster-name

--- a/bin/bootstrap-infrastructure-google
+++ b/bin/bootstrap-infrastructure-google
@@ -5,7 +5,12 @@ set -eu
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 _cluster_name() {
-  echo "${CLUSTER_NAME:="$(whoami)-dev"}"
+  [[ -f state/google/cluster-name ]] || {
+    mkdir -p state/google
+    ${CLUSTER_NAME:="$(whoami)-$(LC_ALL=C tr -dc 'a-z0-9' </dev/urandom | head -c 6 ; echo)"}
+    echo "$CLUSTER_NAME" > state/google/cluster-name
+  }
+  cat state/google/cluster-name
 }
 
 _setup_env() {


### PR DESCRIPTION
Bootstrapping new google cluster will now generate a random cluster name prefixed (like now) with your local `whoami`.

```
$ bootstrap-kubernetes-demos up --google
...

$ tree state
state
├── configuration
├── google
│   └── cluster-name
├── infrastructure
└── systems
    └── zzz-ignoreme
$ cat state/google/cluster-name
drnic-4hdsyy
$ gcloud container clusters list
NAME          LOCATION    MASTER_VERSION  MASTER_IP      MACHINE_TYPE   NODE_VERSION   NUM_NODES  STATUS
drnic-4hdsyy  us-west1-a  1.14.6-gke.13   35.247.69.161  n1-standard-2  1.14.6-gke.13  3          PROVISIONING

$ bootstrap-kubernetes-demos down
Deleting cluster drnic-4hdsyy...⠏
```