### PR TITLE
helm3

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-export PATH=$PWD/bin:$PWD/vendor/helm-tiller-manager/bin:$PATH
+export PATH=$PWD/bin:$PATH

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/helm-tiller-manager"]
-	path = vendor/helm-tiller-manager
-	url = https://github.com/starkandwayne/helm-tiller-manager

--- a/.versions
+++ b/.versions
@@ -1,4 +1,4 @@
-helm-cli=3.0.0-beta.5
+helm-cli=3.0.3
 kubecf=0.2.0
 cf-operator-helm-file=cf-operator-v2.0.0-0.g0142d1e9.tgz
 knative-serving=0.9.0

--- a/.versions
+++ b/.versions
@@ -1,3 +1,4 @@
+helm-cli=3.0.0-beta.5
 kubecf=0.2.0
 cf-operator-helm-file=cf-operator-v2.0.0-0.g0142d1e9.tgz
 knative-serving=0.9.0

--- a/bin/bootstrap-system-cf-operator
+++ b/bin/bootstrap-system-cf-operator
@@ -46,7 +46,19 @@ up() {
   discover_versions
   failfast
 
+  ns=$(_namespace)
+
   echo "Install Cloud Foundry/Quarks (cf-operator)"
+  # create scf namespace - helm3 doesn't do this
+  cat <<YAML | kubectl apply -f -
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: ${ns}
+      labels:
+        cf-operator-ns: ${ns}
+YAML
+
   # hardcoded at moment for current vendor/cf-operator submodule version
   [[ "$(command -v aws)X" != "X" && -f ~/.aws/credentials ]] && {
     release_date=$(aws s3 ls s3://cf-operators/helm-charts/ | grep "$CF_OPERATOR_HELM_FILE" | awk '{print $1}')
@@ -62,7 +74,6 @@ up() {
   # cf-operator versions have + in them; let's encode that as %2B
   CF_OPERATOR_HELM_TGZ=${CF_OPERATOR_HELM_TGZ//'+'/%2B}
 
-  ns=$(_namespace)
   (
   set -x
   helm upgrade --install --wait --namespace "$ns" \

--- a/bin/bootstrap-system-helm
+++ b/bin/bootstrap-system-helm
@@ -2,7 +2,8 @@
 
 set -eu
 
-cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+repo_root="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+cd "$repo_root"
 
 # Install S&W Helm Charts rather than some arbitrary default of nonsense
 export STABLE_REPO_URL=${STABLE_REPO_URL:-https://helm.starkandwayne.com}
@@ -13,36 +14,35 @@ export HELM_MGR_STATE_ROOT=${HELM_MGR_STATE_ROOT:-$PWD/state/helm}
 # helm-manager sets up TLS for tiller; so use `--tls` for all helm commands
 export HELM_TLS_VERIFY=${HELM_TLS_VERIFY:-true}
 
-cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+_platform() {
+    if [ "$(uname)" == "Darwin" ]; then
+        echo "darwin"
+    elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+        echo "linux"
+    fi
+}
 
-failfast() {
-  [[ -d vendor/helm-tiller-manager ]] || {
-    >&2 echo "Fetching missing submodules..."
-    git submodule update --init
-  }
+_ensure_helm3() {
+    version=$(grep "helm-cli" "${repo_root}/.versions" | cut -d= -f2)
+    platform=$(_platform)
+    [[ "$(command -v helm)X" == "X" || "$(helm version | grep "$version")X" == "X" ]] && {
+        echo "installing helm v${version} into ${repo_root}/bin/"
+        (
+        url="https://get.helm.sh/helm-v${version}-${platform}-amd64.tar.gz"
+        cd "$(mktemp -d)"
+        curl -sSL "$url" | tar -xvz "${platform}-amd64/helm"
+        chmod +x "${platform}-amd64/helm"
+        mv "${platform}-amd64/helm" "${repo_root}/bin/"
+        )
+    }
+    printf '' # ensure happy exit regardless of [[ test ]] block
 }
 
 up() {
-  echo "Install/upgrade Tiller Server for Helm"
-  helm-manager up
-  helm repo update
-  [[ "${CREDHUB_BASE_PATH:-X}" != "X" ]] && {
-    echo "Storing helm into credhub ${CREDHUB_BASE_PATH}..."
-    [[ -f $(helm home)/ca.pem ]] && {
-      credhub set -n "${CREDHUB_BASE_PATH}/helm-ca" -t value -v "$(cat "$(helm home)/ca.pem")"
-      credhub set -n "${CREDHUB_BASE_PATH}/helm-tiller-cert" -t value -v "$(cat "$(helm home)/cert.pem")"
-      credhub set -n "${CREDHUB_BASE_PATH}/helm-tiller-key" -t value -v "$(cat "$(helm home)/key.pem")"
-    }
-  }
-  exit 0
+  _ensure_helm3
 }
 
 case "${1:-usage}" in
-  failfast)
-    shift
-    failfast "$@"
-    ;;
-
   up)
     shift
     up


### PR DESCRIPTION
The `bootstrap-system-helm up` command now:

- [x] deprecation notice on README of master branch
- [x] installs `helm` CLI (v3+) into `bin/`
- [x] `cf-operator` system creates `scf` namespace as `helm3` no longer does this
- [x] we no longer require the `vendor/helm-tiller-manager` project to setup tiller
- [x] need to upgrade cf-operator to support helm3 (no hook)
- [x] need version of cf-operator/scf that actually work together
