### PR TITLE
Rancher

### DIFF
--- a/bin/bootstrap-infrastructure-digitalocean
+++ b/bin/bootstrap-infrastructure-digitalocean
@@ -13,6 +13,16 @@ _cluster_name() {
   cat state/digitalocean/cluster-name
 }
 
+# doctl k8s options sizes
+NODE_SIZE=${NODE_SIZE:-"s-2vcpu-2gb"}
+_node_size() {
+  [[ -f state/digitalocean/node-size ]] || {
+    mkdir -p state/digitalocean
+    echo "${NODE_SIZE}" > state/digitalocean/node-size
+  }
+  cat state/digitalocean/node-size
+}
+
 failfast() {
   [[ "$(command -v doctl)X" != "X" ]] || {
     echo "ERROR: missing 'doctl' CLI from \$PATH" >> $1
@@ -35,7 +45,7 @@ up() {
     echo "Creating Digital Ocean cluster $(_cluster_name)..."
     doctl kubernetes cluster create "$(_cluster_name)" \
       --auto-upgrade \
-      --node-pool "name=default;size=s-1vcpu-2gb;count=2;auto-scale=true;min-nodes=2;max-nodes=5"
+      --node-pool "name=default;size=$(_node_size);count=2;auto-scale=true;min-nodes=2;max-nodes=5"
   }
 
   status=$(clusterStatus)

--- a/bin/bootstrap-kubernetes-demos
+++ b/bin/bootstrap-kubernetes-demos
@@ -124,6 +124,8 @@ case "${1:-usage}" in
           ;;
         --do|--digitalocean)
           echo "digitalocean" > state/infrastructure
+          echo 1 > state/systems/helm
+          echo 1 > state/systems/nginx-ingress
           ;;
 
         --ingress|--nginx-ingress)

--- a/bin/bootstrap-kubernetes-demos
+++ b/bin/bootstrap-kubernetes-demos
@@ -15,6 +15,7 @@ usage() {
     echo "     [--az|--azure]         -- bootstrap new Azure AKE cluster"
     echo "     [--do|--digitalocean]  -- bootstrap new Digital Ocean cluster"
     echo ""
+    echo "     [--ingress|--nginx-ingress] -- deploys Nginx Ingress"
     echo "     [--cert-manager]       -- deploys cert-manager"
     echo "     [--k-rail|--krail]     -- deploys k-rail to enforce policies for end users"
     echo "     [--helm|--tiller]      -- deploys secure Helm Tiller (deprecated)"
@@ -39,6 +40,7 @@ usage() {
 # TODO: would be nice to discover available systems from bin/bootstrap-system-* and discover dependencies
 _available_systems() {
   echo "
+    nginx-ingress
     cert-manager
     k-rail
     helm
@@ -123,11 +125,11 @@ case "${1:-usage}" in
         --do|--digitalocean)
           echo "digitalocean" > state/infrastructure
           ;;
-        # --cfcontainers)
-        # Is this section really for Diego for SCF?
-        #   echo 1 > state/systems/cfcontainers
-        #   echo 1 > state/systems/helm
-        #   ;;
+
+        --ingress|--nginx-ingress)
+          echo 1 > state/systems/helm
+          echo 1 > state/systems/nginx-ingress
+          ;;
         --kubecf|--cf|--scf|--eirini)
           echo 1 > state/systems/helm
           echo 1 > state/systems/cf-operator

--- a/bin/bootstrap-kubernetes-demos
+++ b/bin/bootstrap-kubernetes-demos
@@ -24,6 +24,7 @@ usage() {
     echo "     [--kpack]              -- deploys kpack to build images with buildpacks"
     echo "     [--tekton]             -- deploys Tekton CD"
     echo "     [--knative]            -- deploys Knative Serving/Eventing/Istio"
+    echo "     [--rancher]            -- deploys Rancher"
     echo "     [--rio]                -- deploys Rancher Rio"
     # echo "     [--knative-addr-name name] -- map GCP address to ingress gateway"
     echo "     [--kubeapp]                -- deploys Kubeapps"
@@ -45,7 +46,7 @@ _available_systems() {
     servicecatalog cf-broker
     cf-operator kubecf
     kpack tekton knative
-    rio
+    rio rancher
   "
 }
 
@@ -150,6 +151,11 @@ case "${1:-usage}" in
           ;;
         --knative)
           echo 1 > state/systems/knative
+          ;;
+        --rancher)
+          echo 1 > state/systems/helm
+          echo 1 > state/systems/cert-manager
+          echo 1 > state/systems/rancher
           ;;
         --rio)
           echo 1 > state/systems/rio

--- a/bin/bootstrap-system-cert-manager
+++ b/bin/bootstrap-system-cert-manager
@@ -21,6 +21,10 @@ up() {
     echo "Installing cert-manager v$VERSION..."
     set -x
     kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v$VERSION/cert-manager.yaml
+
+    kubectl rollout status -n cert-manager deployment/cert-manager
+    kubectl rollout status -n cert-manager deployment/cert-manager-cainjector
+    kubectl rollout status -n cert-manager deployment/cert-manager-webhook
   )
 }
 

--- a/bin/bootstrap-system-nginx-ingress
+++ b/bin/bootstrap-system-nginx-ingress
@@ -17,6 +17,11 @@ up() {
     --namespace "$(_namespace)" \
     --set controller.publishService.enabled=true
   kubectl -n "$(_namespace)" rollout status deploy/nginx-ingress-controller
+
+  # TODO: block until LoadBalancer has now been created
+  ingress_external_ip=$(kubectl get service -n kube-system nginx-ingress-controller -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  echo "${ingress_external_ip}" > state/configuration/ingress-external-ip
+  echo "${ingress_external_ip}.xip.io" > state/configuration/ingress-domain
 }
 
 down() {

--- a/bin/bootstrap-system-nginx-ingress
+++ b/bin/bootstrap-system-nginx-ingress
@@ -30,6 +30,8 @@ up() {
 
   echo "${ingress_external_ip}" > state/configuration/ingress-external-ip
   echo "${ingress_external_ip}.xip.io" > state/configuration/ingress-domain
+
+  echo
 }
 
 down() {

--- a/bin/bootstrap-system-nginx-ingress
+++ b/bin/bootstrap-system-nginx-ingress
@@ -5,28 +5,22 @@ set -eu
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 _namespace() {
-  printf "cattle-system"
-}
-
-_hostname() {
-  printf "rancher.mydev"
+  printf "kube-system"
 }
 
 up() {
-  echo "Install/upgrade Rancher via Helm"
-  helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
-  kubectl create namespace cattle-system || { echo '-> continuing...'; }
-  helm upgrade --install rancher rancher-latest/rancher \
-    --namespace "$(_namespace)" \
-    --set ingress.tls.source=rancher \
-    --set hostname="$(_hostname)"
-  kubectl -n "$(_namespace)" rollout status deploy/rancher
+  echo "Install/upgrade Nginx Ingress via Helm"
+  helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+  helm repo update
+  helm upgrade --install nginx-ingress stable/nginx-ingress \
+    --namespace "$(_namespace)"
+  kubectl -n "$(_namespace)" rollout status deploy/nginx-ingress-controller
 }
 
 down() {
   namespace=$(_namespace)
   set +x
-  helm delete rancher -n "$(_namespace)"
+  helm delete nginx-ingress -n "$(_namespace)"
 }
 
 kwt_routing() {

--- a/bin/bootstrap-system-nginx-ingress
+++ b/bin/bootstrap-system-nginx-ingress
@@ -12,8 +12,10 @@ up() {
   echo "Install/upgrade Nginx Ingress via Helm"
   helm repo add stable https://kubernetes-charts.storage.googleapis.com/
   helm repo update
+  # https://www.digitalocean.com/community/tutorials/how-to-set-up-an-nginx-ingress-on-digitalocean-kubernetes-using-helm
   helm upgrade --install nginx-ingress stable/nginx-ingress \
-    --namespace "$(_namespace)"
+    --namespace "$(_namespace)" \
+    --set controller.publishService.enabled=true
   kubectl -n "$(_namespace)" rollout status deploy/nginx-ingress-controller
 }
 

--- a/bin/bootstrap-system-nginx-ingress
+++ b/bin/bootstrap-system-nginx-ingress
@@ -9,17 +9,25 @@ _namespace() {
 }
 
 up() {
+  # https://www.digitalocean.com/community/tutorials/how-to-set-up-an-nginx-ingress-on-digitalocean-kubernetes-using-helm
+
   echo "Install/upgrade Nginx Ingress via Helm"
   helm repo add stable https://kubernetes-charts.storage.googleapis.com/
   helm repo update
-  # https://www.digitalocean.com/community/tutorials/how-to-set-up-an-nginx-ingress-on-digitalocean-kubernetes-using-helm
   helm upgrade --install nginx-ingress stable/nginx-ingress \
     --namespace "$(_namespace)" \
     --set controller.publishService.enabled=true
+  echo "-- waiting for ingress controller"
   kubectl -n "$(_namespace)" rollout status deploy/nginx-ingress-controller
 
-  # TODO: block until LoadBalancer has now been created
+  echo "-- waiting for ingress load balancer"
   ingress_external_ip=$(kubectl get service -n kube-system nginx-ingress-controller -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  while [[ "${ingress_external_ip:-X}" == "X" ]]; do
+    printf "."
+    sleep 5
+    ingress_external_ip=$(kubectl get service -n kube-system nginx-ingress-controller -o=jsonpath='{.status.loadBalancer.ingress[0].ip}')
+  done
+
   echo "${ingress_external_ip}" > state/configuration/ingress-external-ip
   echo "${ingress_external_ip}.xip.io" > state/configuration/ingress-domain
 }

--- a/bin/bootstrap-system-rancher
+++ b/bin/bootstrap-system-rancher
@@ -4,21 +4,53 @@ set -eu
 
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
+_namespace() {
+  printf "cattle-system"
+}
+
+_hostname() {
+  printf "rancher.mydev"
+}
+
 up() {
   echo "Install/upgrade Rancher via Helm"
   helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
   kubectl create namespace cattle-system || { echo '-> continuing...'; }
   helm upgrade --install rancher rancher-latest/rancher \
-    --namespace cattle-system \
+    --namespace "$(_namespace)" \
     --set ingress.tls.source=rancher \
-    --set hostname=rancher.dev
+    --set hostname="$(_hostname)"
   kubectl -n cattle-system rollout status deploy/rancher
+}
+
+down() {
+  namespace=$(_namespace)
+  set +x
+  helm delete rancher -n cattle-system
+}
+
+kwt_routing() {
+  [[ "$(command -v kwt)X" != "X" ]] || { echo "ERROR: install 'kwt'"; exit 1; }
+
+  api_ip=$(kubectl get svc -n "$(_namespace)" rancher --template '{{.spec.clusterIP}}')
+
+  echo "Mapping https://$(_hostname) to internal IP ${api_ip}..."
+  echo
+  hostname=$(_hostname)
+  namespace=$(_namespace)
+  set -x
+  sudo -E kwt net start --dns-map "${hostname}=${api_ip}" --namespace "$namespace"
 }
 
 case "${1:-usage}" in
   up)
     shift
     up
+    ;;
+
+  kwt)
+    shift
+    kwt_routing
     ;;
 
   *)

--- a/bin/bootstrap-system-rancher
+++ b/bin/bootstrap-system-rancher
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eu
+
+cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+up() {
+  echo "Install/upgrade Rancher via Helm"
+  helm repo add rancher-latest https://releases.rancher.com/server-charts/latest
+  kubectl create namespace cattle-system || { echo '-> continuing...'; }
+  helm upgrade --install rancher rancher-latest/rancher \
+    --namespace cattle-system \
+    --wait \
+    --set ingress.tls.source=rancher \
+    --set hostname=rancher.dev
+}
+
+case "${1:-usage}" in
+  up)
+    shift
+    up
+    ;;
+
+  *)
+    ;;
+esac

--- a/bin/bootstrap-system-rancher
+++ b/bin/bootstrap-system-rancher
@@ -9,7 +9,11 @@ _namespace() {
 }
 
 _hostname() {
-  printf "rancher.mydev"
+  if [[ -f state/configuration/ingress-domain ]]; then
+    echo "rancher.$(cat state/configuration/ingress-domain)"
+  else
+    echo "rancher.mydev"
+  fi
 }
 
 up() {

--- a/bin/bootstrap-system-rancher
+++ b/bin/bootstrap-system-rancher
@@ -10,9 +10,9 @@ up() {
   kubectl create namespace cattle-system || { echo '-> continuing...'; }
   helm upgrade --install rancher rancher-latest/rancher \
     --namespace cattle-system \
-    --wait \
     --set ingress.tls.source=rancher \
     --set hostname=rancher.dev
+  kubectl -n cattle-system rollout status deploy/rancher
 }
 
 case "${1:-usage}" in


### PR DESCRIPTION
We can now deploy Rancher UI atop of the Kubernetes cluster.

This PR also adds changes that were required for this feature:

* cert-manager - now blocks until the deployment has finished rolling out
* nginx-ingress - automatically deployed to digitalocean so that all kubernetes equally have ingress; automatically stores the LoadBalancer IP + and an .xip.io in `state/configuration` files
* rancher - looks up `state/configuration` for the xip.io

NOTE: https://github.com/rancher/rancher/issues/16213

Once you've logged into Rancher, the `local` cluster will not "provision". You need to edit and save it, and then the local cluster will be available.