### PR TITLE
KubeCF ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,12 @@ ADMIN_PASSWORD=$(kubectl get secret kubecf.var-cf-admin-password -ojsonpath='{.d
 cf login -a https://api.$SYSTEM_DOMAIN --skip-ssl-validation -u admin -p $ADMIN_PASSWORD
 ```
 
+This is also available via:
+
+```plain
+bootstrap-system-kubecf login
+```
+
 ### Access to KubeCF
 
 Currently this CF deployment does not setup a public ingress into the Cloud Foundry router. Nor will it ever set up your public DNS to map to your Cloud Foundry ingress/router.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ bootstrap-kubernetes-demos up --azure
 bootstrap-kubernetes-demos up --digitalocean
 ```
 
-The Digital Ocean cluster will install 2 x 2 CPU/2Gb nodes, and will install the nginx-ingress controller.
+The Digital Ocean cluster will install 3 x 2 CPU/2Gb nodes, and will install the nginx-ingress controller.
 
 ## Subsystems
 

--- a/README.md
+++ b/README.md
@@ -191,22 +191,25 @@ Put that in your `.profile` for all terminal sessions.
 
 ## Cloud Foundry / Eirini / Quarks
 
-To bootstrap GKE, and then install Cloud Foundry (with Eirini/Quarks) use the `--cf` flag (or `--kubecf`, or `--eirini` flags):
+To bootstrap GKE, and then install Cloud Foundry (with Eirini/Quarks) use the `--cf` flag (or `--kubecf`, or `--eirini` flags). The explicit `--ingress` flag will automatically setup a default `.xip.io` system domain.
 
 ```plain
-bootstrap-kubernetes-demos up --kubecf
-bootstrap-kubernetes-demos up --google --cf
-bootstrap-kubernetes-demos up --azure --cf
-```
-
-You can override some defaults by setting the following environment variables before running the command above:
-
-```bash
-: ${CF_SYSTEM_DOMAIN:=kubecf.dev}
-: ${CF_NAMESPACE:=kubecf}
+bootstrap-kubernetes-demos up --cf --ingress
+bootstrap-kubernetes-demos up --google --cf --ingress
+bootstrap-kubernetes-demos up --azure --cf --ingress
+bootstrap-kubernetes-demos up --digitalocean --cf --ingress
 ```
 
 Your Cloud Foundry Buildpacks will be automatically updated to the latest from GitHub, and each day a cronjob will run to update them again.
+
+To target and login:
+
+```plain
+SYSTEM_DOMAIN=$(kubectl get secret kubecf.var-system-domain -ojsonpath='{.data.value}' | base64 --decode)
+ADMIN_PASSWORD=$(kubectl get secret kubecf.var-cf-admin-password -ojsonpath='{.data.password}' | base64 --decode)
+
+cf login -a https://api.$SYSTEM_DOMAIN --skip-ssl-validation -u admin -p $ADMIN_PASSWORD
+```
 
 ### Access to KubeCF
 

--- a/README.md
+++ b/README.md
@@ -194,10 +194,10 @@ Put that in your `.profile` for all terminal sessions.
 To bootstrap GKE, and then install Cloud Foundry (with Eirini/Quarks) use the `--cf` flag (or `--kubecf`, or `--eirini` flags). The explicit `--ingress` flag will automatically setup a default `.xip.io` system domain.
 
 ```plain
-bootstrap-kubernetes-demos up --cf --ingress
-bootstrap-kubernetes-demos up --google --cf --ingress
-bootstrap-kubernetes-demos up --azure --cf --ingress
-bootstrap-kubernetes-demos up --digitalocean --cf --ingress
+bootstrap-kubernetes-demos up --cf
+bootstrap-kubernetes-demos up --google --cf
+bootstrap-kubernetes-demos up --azure --cf
+bootstrap-kubernetes-demos up --digitalocean --cf
 ```
 
 Your Cloud Foundry Buildpacks will be automatically updated to the latest from GitHub, and each day a cronjob will run to update them again.

--- a/bin/bootstrap-infrastructure-digitalocean
+++ b/bin/bootstrap-infrastructure-digitalocean
@@ -23,6 +23,15 @@ _node_size() {
   cat state/digitalocean/node-size
 }
 
+CLUSTER_SIZE=${CLUSTER_SIZE:-"3"}
+_cluster_size() {
+  [[ -f state/digitalocean/cluster-size ]] || {
+    mkdir -p state/digitalocean
+    echo "${CLUSTER_SIZE}" > state/digitalocean/cluster-size
+  }
+  cat state/digitalocean/cluster-size
+}
+
 failfast() {
   [[ "$(command -v doctl)X" != "X" ]] || {
     echo "ERROR: missing 'doctl' CLI from \$PATH" >> $1
@@ -45,7 +54,7 @@ up() {
     echo "Creating Digital Ocean cluster $(_cluster_name)..."
     doctl kubernetes cluster create "$(_cluster_name)" \
       --auto-upgrade \
-      --node-pool "name=default;size=$(_node_size);count=2;auto-scale=true;min-nodes=2;max-nodes=5"
+      --node-pool "name=default;size=$(_node_size);count=$(_cluster_size);auto-scale=true;min-nodes=2;max-nodes=5"
   }
 
   status=$(clusterStatus)
@@ -56,11 +65,6 @@ up() {
   done
 
   doctl kubernetes cluster kubeconfig save "$(_cluster_name)"
-
-  # kubectl create clusterrolebinding cluster-admin-binding \
-  #   --clusterrole=cluster-admin \
-  #   --user="$(gcloud config get-value core/account)" \
-  #   --dry-run=true -o yaml | kubectl apply -f -
 
   exit 0
 }

--- a/bin/bootstrap-kubernetes-demos
+++ b/bin/bootstrap-kubernetes-demos
@@ -132,8 +132,14 @@ case "${1:-usage}" in
           echo 1 > state/systems/helm
           echo 1 > state/systems/nginx-ingress
           ;;
+
+        --no-ingress|--no-nginx-ingress)
+          rm state/systems/nginx-ingress
+          ;;
+
         --kubecf|--cf|--scf|--eirini)
           echo 1 > state/systems/helm
+          echo 1 > state/systems/nginx-ingress
           echo 1 > state/systems/cf-operator
           echo 1 > state/systems/kubecf
           ;;
@@ -141,6 +147,7 @@ case "${1:-usage}" in
           echo 1 > state/systems/helm
           echo 1 > state/systems/cf-operator
           ;;
+
         --cert-manager)
           echo 1 > state/systems/cert-manager
           ;;

--- a/bin/bootstrap-system-cf-operator
+++ b/bin/bootstrap-system-cf-operator
@@ -8,6 +8,13 @@ export HELM_TLS_VERIFY=${HELM_TLS_VERIFY:-true}
 cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 _namespace() {
+  [[ -f state/configuration/cf-operator-namespace ]] || {
+    echo "${CF_OPERATOR_NAMESPACE:-kubecf-operator}" > state/configuration/cf-operator-namespace
+  }
+  cat state/configuration/cf-operator-namespace
+}
+
+_kubecf_namespace() {
   [[ -f state/configuration/kubecf-namespace ]] || {
     echo "${CF_NAMESPACE:-kubecf}" > state/configuration/kubecf-namespace
   }
@@ -47,6 +54,7 @@ up() {
   failfast
 
   ns=$(_namespace)
+  watchNamespace=$(_kubecf_namespace)
 
   echo "Install Cloud Foundry/Quarks (cf-operator)"
   # create scf namespace - helm3 doesn't do this
@@ -80,6 +88,7 @@ YAML
     cf-operator \
     "${CF_OPERATOR_HELM_TGZ}" \
     ${CFOPERATOR_TAG:+--set "image.tag=${CFOPERATOR_TAG}"} \
+    --set "global.operator.watchNamespace=${watchNamespace}" \
     --set "provider=gke" \
     --set "operator-webhook-use-service-reference=true" # coming in future
   )
@@ -99,10 +108,10 @@ restart() {
 }
 
 down() {
-  helm delete cf-operator --purge
+  helm delete cf-operator -n "$(_namespace)"
 
-  kubectl delete validatingwebhookconfigurations -l name=cf-operator-webhook
-  kubectl delete mutatingwebhookconfigurations -l name=cf-operator-webhook
+  kubectl delete validatingwebhookconfigurations cf-operator-hook-"$(_namespace)"
+  kubectl delete mutatingwebhookconfigurations cf-operator-hook-"$(_namespace)"
 }
 
 case "${1:-usage}" in

--- a/bin/bootstrap-system-kubecf
+++ b/bin/bootstrap-system-kubecf
@@ -99,21 +99,19 @@ YAML
   )
 }
 
-kwt_routing() {
-  [[ "$(command -v kwt)X" != "X" ]] || { echo "ERROR: install 'kwt'"; exit 1; }
+login() {
+  printf "Fetching system domain... "
+  SYSTEM_DOMAIN=$(kubectl get secret kubecf.var-system-domain -ojsonpath='{.data.value}' | base64 --decode)
+  echo "$SYSTEM_DOMAIN"
 
-  api_ip=$(kubectl get svc -n "$(_namespace)" kubecf-router-0 --template '{{.spec.clusterIP}}')
+  printf "Fetching admin password... "
+  ADMIN_PASSWORD=$(kubectl get secret kubecf.var-cf-admin-password -ojsonpath='{.data.password}' | base64 --decode)
+  echo "done."
+  echo
 
-  echo "Mapping *.$(_system_domain) to internal IP ${api_ip}..."
+  echo "+ cf login -a https://api.$SYSTEM_DOMAIN --skip-ssl-validation -u admin -p [redacted]"
   echo
-  echo "Login with:"
-  echo "cf login -a https://api.$(_system_domain) --skip-ssl-validation -u admin \\"
-  echo '   -p "$(kubectl get secret -n kubecf kubecf.var-cf-admin-password -o json | jq -r .data.password | base64 --decode)"'
-  echo
-  system_domain=$(_system_domain)
-  namespace=$(_namespace)
-  set -x
-  sudo -E kwt net start --dns-map "${system_domain}=${api_ip}" --namespace "$namespace"
+  cf login -a https://api.$SYSTEM_DOMAIN --skip-ssl-validation -u admin -p $ADMIN_PASSWORD
 }
 
 case "${1:-usage}" in
@@ -127,9 +125,9 @@ case "${1:-usage}" in
     up
     ;;
 
-  kwt)
+  login)
     shift
-    kwt_routing
+    login
     ;;
 
   *)

--- a/bin/bootstrap-system-kubecf
+++ b/bin/bootstrap-system-kubecf
@@ -6,7 +6,11 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
 _system_domain() {
   [[ -f state/configuration/kubecf-system-domain ]] || {
+    if [[ -f state/configuration/ingress-domain ]]; then
+      cp state/configuration/ingress-domain state/configuration/kubecf-system-domain
+    else
     echo "${CF_SYSTEM_DOMAIN:-kubecf.dev}" > state/configuration/kubecf-system-domain
+    fi
   }
   cat state/configuration/kubecf-system-domain
 }


### PR DESCRIPTION
The `--kubecf` installation now installs nginx-ingress and uses `<ip>.xip.io` as the system domain.

Additionally in this PR:

* Digital Ocean deployment is now 3 nodes (2 vCPU 2GiB each)
* `cf-operator` deployed into separate `kubecf-operator` namespace, which watches `kubecf` namespace
* `bootstrap-system-kubecf login` will run `cf login` for admin user
